### PR TITLE
Debug nccl shared object file not found error

### DIFF
--- a/NCCL_FIX_GUIDE.md
+++ b/NCCL_FIX_GUIDE.md
@@ -1,0 +1,201 @@
+# NCCL 库找不到问题的解决方案
+
+## 问题诊断
+
+您遇到的错误：`/usr/lib/x86_64-linux-gnu/libnccl.so.2: cannot open shared object file: No such file or directory`
+
+## 常见原因
+
+1. **bashrc 未被加载**：在非交互式 shell（如通过脚本、cron、systemd 启动）中，`~/.bashrc` 不会自动加载
+2. **路径不存在**：设置的路径可能实际不存在
+3. **库文件名不匹配**：库文件可能是 `libnccl.so.2.x.x` 而不是 `libnccl.so.2`
+
+## 解决方案
+
+### 步骤 1：验证 NCCL 库是否存在
+
+```bash
+# 检查您设置的路径中是否真的有 NCCL 库
+ls -la /mnt/shared-storage-user/ailab-sys/matenghui/miniconda3/envs/internevo/lib/python3.10/site-packages/nvidia/nccl/lib/
+
+# 或者在整个 conda 环境中搜索
+find ~/miniconda3/envs/internevo -name "libnccl.so*" 2>/dev/null
+```
+
+### 步骤 2：找到正确的 NCCL 库路径
+
+NCCL 库通常在以下位置之一：
+
+```bash
+# PyTorch 自带的 NCCL
+~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib/
+
+# Conda 安装的 NCCL
+~/miniconda3/envs/internevo/lib/
+
+# 系统安装的 NCCL
+/usr/lib/x86_64-linux-gnu/
+```
+
+查找命令：
+```bash
+# 在 conda 环境中查找
+find ~/miniconda3/envs/internevo -name "libnccl.so*"
+
+# 检查 PyTorch 目录
+ls -la ~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib/ | grep nccl
+```
+
+### 步骤 3：修复方法
+
+#### 方法 1：使用启动脚本（推荐）
+
+创建一个启动脚本 `run_train.sh`：
+
+```bash
+#!/bin/bash
+
+# 激活 conda 环境
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate internevo
+
+# 设置 LD_LIBRARY_PATH（请替换为实际路径）
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib:$LD_LIBRARY_PATH
+
+# 验证 NCCL 库可以找到
+echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+ldconfig -p | grep nccl || echo "Warning: NCCL not found in system cache"
+
+# 运行训练脚本
+python train.py "$@"
+```
+
+使用方法：
+```bash
+chmod +x run_train.sh
+./run_train.sh --config configs/7B_sft.py
+```
+
+#### 方法 2：修改 ~/.bashrc 并确保加载
+
+编辑 `~/.bashrc`：
+
+```bash
+# 在文件末尾添加
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib:$LD_LIBRARY_PATH
+```
+
+然后在启动训练前**显式加载**：
+```bash
+source ~/.bashrc
+python train.py --config configs/7B_sft.py
+```
+
+#### 方法 3：使用 ~/.bash_profile（用于非交互式会话）
+
+编辑或创建 `~/.bash_profile`：
+
+```bash
+# 加载 .bashrc
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi
+
+# 或直接在这里设置
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib:$LD_LIBRARY_PATH
+```
+
+#### 方法 4：创建符号链接（如果有 root 权限）
+
+```bash
+# 找到实际的 NCCL 库位置
+NCCL_PATH=$(find ~/miniconda3/envs/internevo -name "libnccl.so.2*" | head -1)
+echo "Found NCCL at: $NCCL_PATH"
+
+# 创建符号链接（需要 sudo）
+sudo ln -s $NCCL_PATH /usr/lib/x86_64-linux-gnu/libnccl.so.2
+```
+
+#### 方法 5：在 Python 脚本中设置（临时方案）
+
+在 `train.py` 的开头添加：
+
+```python
+import os
+import sys
+
+# 设置 LD_LIBRARY_PATH
+nccl_path = os.path.expanduser("~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib")
+os.environ['LD_LIBRARY_PATH'] = f"{nccl_path}:{os.environ.get('LD_LIBRARY_PATH', '')}"
+
+# 注意：这可能不会对已经加载的库生效
+```
+
+### 步骤 4：验证修复
+
+运行以下命令验证：
+
+```bash
+# 激活环境
+conda activate internevo
+
+# 检查环境变量
+echo $LD_LIBRARY_PATH
+
+# 测试 NCCL 是否可用
+python3 -c "import torch; print('CUDA available:', torch.cuda.is_available()); print('NCCL available:', torch.cuda.nccl.version())"
+```
+
+## 调试命令
+
+```bash
+# 查看当前加载的库
+ldd $(which python) | grep nccl
+
+# 查看 PyTorch 使用的 NCCL 版本
+python -c "import torch; print(torch.cuda.nccl.version())"
+
+# 检查系统 NCCL 库
+ldconfig -p | grep nccl
+
+# 查找所有 NCCL 库
+find /usr -name "libnccl.so*" 2>/dev/null
+find ~ -name "libnccl.so*" 2>/dev/null
+```
+
+## 注意事项
+
+1. **路径必须存在**：确保设置的路径中确实有 `libnccl.so.2` 文件
+2. **使用绝对路径**：避免使用 `~` 符号，改用完整路径如 `/home/username/...`
+3. **多路径设置**：可以设置多个路径，用 `:` 分隔
+4. **环境激活顺序**：先激活 conda 环境，再设置 LD_LIBRARY_PATH
+5. **slurm/pbs 任务**：在作业脚本中显式设置环境变量
+
+## 推荐的最佳实践
+
+创建一个环境配置文件 `env_setup.sh`：
+
+```bash
+#!/bin/bash
+
+# 初始化 conda
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate internevo
+
+# 设置库路径
+export TORCH_LIB=$(python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))")
+export LD_LIBRARY_PATH=$TORCH_LIB:$LD_LIBRARY_PATH
+
+echo "Environment setup complete"
+echo "PyTorch location: $(python -c 'import torch; print(torch.__file__)')"
+echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+```
+
+使用：
+```bash
+source env_setup.sh
+python train.py --config configs/7B_sft.py
+```

--- a/NCCL_QUICK_FIX.md
+++ b/NCCL_QUICK_FIX.md
@@ -1,0 +1,214 @@
+# NCCL 库找不到问题 - 快速修复指南
+
+## 问题描述
+
+错误信息：
+```
+Error: /usr/lib/x86_64-linux-gnu/libnccl.so.2: cannot open shared object file: No such file or directory
+```
+
+即使在 `~/.bashrc` 中设置了 `LD_LIBRARY_PATH`，程序仍然找不到 NCCL 库。
+
+## 根本原因
+
+**`~/.bashrc` 只在交互式 shell 中加载**，在以下情况下不会自动加载：
+- 通过脚本启动程序
+- 使用 SLURM/PBS 作业调度系统
+- SSH 执行远程命令
+- cron 任务
+- systemd 服务
+
+## 快速修复方案
+
+### 🔧 方案 1：使用诊断脚本（推荐第一步）
+
+```bash
+# 运行诊断脚本，找到 NCCL 库的实际位置
+./diagnose_nccl.sh
+```
+
+这将显示：
+- NCCL 库文件在哪里
+- 当前环境配置
+- 具体的修复建议
+
+### 🚀 方案 2：使用自动修复的启动脚本（最简单）
+
+```bash
+# 直接使用提供的启动脚本
+./run_train_with_nccl.sh --config configs/7B_sft.py
+
+# 或者带其他参数
+./run_train_with_nccl.sh --config configs/7B_sft.py --launcher slurm
+```
+
+这个脚本会自动：
+1. 激活 conda 环境
+2. 查找 NCCL 库
+3. 设置正确的 LD_LIBRARY_PATH
+4. 启动训练
+
+### 🔨 方案 3：使用环境配置文件
+
+```bash
+# 在运行训练前 source 这个文件
+source setup_nccl_env.sh
+
+# 然后正常运行训练
+python train.py --config configs/7B_sft.py
+```
+
+### ✏️ 方案 4：手动修复（如果知道 NCCL 路径）
+
+运行诊断脚本后，如果找到了 NCCL 库，例如在：
+```
+~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib/libnccl.so.2
+```
+
+则在启动训练前执行：
+```bash
+# 激活 conda 环境
+conda activate internevo
+
+# 设置库路径（使用您实际找到的路径）
+export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+
+# 验证
+python -c "import torch; print('NCCL version:', torch.cuda.nccl.version())"
+
+# 运行训练
+python train.py --config configs/7B_sft.py
+```
+
+## 使用 SLURM 时的修复
+
+在您的 SLURM 作业脚本中：
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=train
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:8
+
+# 激活环境
+source ~/miniconda3/etc/profile.d/conda.sh
+conda activate internevo
+
+# 方法 A: source 环境配置（推荐）
+source /path/to/workspace/setup_nccl_env.sh
+
+# 或者 方法 B: 使用启动脚本
+# ./run_train_with_nccl.sh --config configs/7B_sft.py
+
+# 或者 方法 C: 手动设置（使用实际路径）
+# export LD_LIBRARY_PATH=~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+
+# 运行训练
+python train.py --config configs/7B_sft.py
+```
+
+## 永久修复（可选）
+
+如果您想让设置永久生效，修改 `~/.bash_profile`（而不是 `~/.bashrc`）：
+
+```bash
+# 编辑 ~/.bash_profile
+nano ~/.bash_profile
+
+# 添加以下内容（使用您实际的路径）
+export LD_LIBRARY_PATH=$HOME/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$HOME/miniconda3/envs/internevo/lib:$LD_LIBRARY_PATH
+
+# 保存后，重新登录或执行
+source ~/.bash_profile
+```
+
+## 常见 NCCL 库位置
+
+按优先级排序：
+
+1. **PyTorch 自带**（推荐使用）
+   ```
+   ~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib/
+   ```
+
+2. **Conda 环境**
+   ```
+   ~/miniconda3/envs/internevo/lib/
+   ```
+
+3. **Nvidia 包**
+   ```
+   ~/miniconda3/envs/internevo/lib/python3.10/site-packages/nvidia/nccl/lib/
+   ```
+
+4. **系统安装**
+   ```
+   /usr/lib/x86_64-linux-gnu/
+   ```
+
+## 验证修复
+
+运行以下命令确认 NCCL 可用：
+
+```bash
+python -c "import torch; print('PyTorch:', torch.__version__); print('CUDA available:', torch.cuda.is_available()); print('NCCL version:', torch.cuda.nccl.version())"
+```
+
+预期输出类似：
+```
+PyTorch: 2.1.0+cu121
+CUDA available: True
+NCCL version: (2, 18, 3)
+```
+
+## 故障排除
+
+如果仍然有问题：
+
+1. **确认库文件存在**
+   ```bash
+   ls -la ~/miniconda3/envs/internevo/lib/python3.10/site-packages/torch/lib/libnccl.so*
+   ```
+
+2. **检查文件权限**
+   ```bash
+   # 应该有读取权限
+   ls -la <NCCL库路径>
+   ```
+
+3. **检查环境变量是否真的设置了**
+   ```bash
+   echo $LD_LIBRARY_PATH
+   ```
+
+4. **使用绝对路径**
+   ```bash
+   # 不要使用 ~ 符号，使用完整路径
+   export LD_LIBRARY_PATH=/home/username/miniconda3/envs/internevo/lib:$LD_LIBRARY_PATH
+   ```
+
+## 为什么 bashrc 不起作用？
+
+`.bashrc` vs `.bash_profile` vs 启动脚本：
+
+| 启动方式 | ~/.bashrc | ~/.bash_profile | 启动脚本 |
+|---------|-----------|-----------------|---------|
+| 交互式登录 | ❌ | ✅ | ✅ |
+| SSH 命令 | ❌ | ❌ | ✅ |
+| SLURM 作业 | ❌ | ❌ | ✅ |
+| Cron 任务 | ❌ | ❌ | ✅ |
+| 手动终端 | ✅ | ✅ | ✅ |
+
+**结论**：对于自动化任务和作业调度，使用启动脚本或在脚本中显式设置环境变量最可靠。
+
+## 联系支持
+
+如果以上方法都不能解决问题，请提供以下信息：
+
+```bash
+# 运行并保存输出
+./diagnose_nccl.sh > nccl_diagnosis.txt 2>&1
+```
+
+将 `nccl_diagnosis.txt` 发送给支持团队。

--- a/diagnose_nccl.sh
+++ b/diagnose_nccl.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# NCCL 问题诊断脚本
+
+echo "========================================="
+echo "NCCL 问题诊断工具"
+echo "========================================="
+
+# 1. 检查 Python 环境
+echo ""
+echo "[1] Python 环境信息:"
+echo "---"
+which python
+python --version
+echo ""
+
+# 2. 检查 PyTorch 和 CUDA
+echo "[2] PyTorch 和 CUDA 信息:"
+echo "---"
+python -c "
+import torch
+print(f'PyTorch 版本: {torch.__version__}')
+print(f'PyTorch 路径: {torch.__file__}')
+print(f'CUDA 可用: {torch.cuda.is_available()}')
+if torch.cuda.is_available():
+    print(f'CUDA 版本: {torch.version.cuda}')
+    print(f'GPU 数量: {torch.cuda.device_count()}')
+try:
+    print(f'NCCL 版本: {torch.cuda.nccl.version()}')
+except Exception as e:
+    print(f'NCCL 检查失败: {e}')
+" 2>&1
+echo ""
+
+# 3. 搜索 NCCL 库文件
+echo "[3] 搜索 NCCL 库文件:"
+echo "---"
+
+# 在 conda 环境中搜索
+if [ -n "$CONDA_PREFIX" ]; then
+    echo "在 Conda 环境中搜索: $CONDA_PREFIX"
+    find "$CONDA_PREFIX" -name "libnccl.so*" 2>/dev/null | while read file; do
+        echo "  找到: $file"
+        ls -lh "$file"
+    done
+fi
+
+# 在用户目录搜索
+echo ""
+echo "在用户目录搜索: $HOME"
+find "$HOME" -name "libnccl.so*" 2>/dev/null | head -10 | while read file; do
+    echo "  找到: $file"
+    ls -lh "$file"
+done
+
+# 在系统目录搜索
+echo ""
+echo "在系统目录搜索: /usr"
+find /usr -name "libnccl.so*" 2>/dev/null | while read file; do
+    echo "  找到: $file"
+    ls -lh "$file"
+done
+echo ""
+
+# 4. 检查当前环境变量
+echo "[4] 当前环境变量:"
+echo "---"
+echo "LD_LIBRARY_PATH:"
+if [ -n "$LD_LIBRARY_PATH" ]; then
+    echo "$LD_LIBRARY_PATH" | tr ':' '\n' | nl
+else
+    echo "  (未设置)"
+fi
+echo ""
+
+echo "CONDA_PREFIX: ${CONDA_PREFIX:-未设置}"
+echo "PATH (前 5 个):"
+echo "$PATH" | tr ':' '\n' | head -5 | nl
+echo ""
+
+# 5. 检查系统库缓存
+echo "[5] 系统库缓存中的 NCCL:"
+echo "---"
+ldconfig -p 2>/dev/null | grep nccl || echo "  未在系统库缓存中找到 NCCL"
+echo ""
+
+# 6. 测试动态链接
+echo "[6] 测试 Python 的动态链接库:"
+echo "---"
+ldd $(which python) | grep nccl || echo "  Python 未直接链接 NCCL（这是正常的）"
+echo ""
+
+# 7. 提供建议
+echo "========================================="
+echo "诊断完成！"
+echo ""
+echo "如果上述搜索找到了 NCCL 库，请将包含该库的目录添加到 LD_LIBRARY_PATH"
+echo ""
+echo "推荐的修复命令："
+echo "1. 如果找到了库文件，例如在 /path/to/lib/libnccl.so.2"
+echo "   export LD_LIBRARY_PATH=/path/to/lib:\$LD_LIBRARY_PATH"
+echo ""
+echo "2. 或者使用提供的启动脚本："
+echo "   ./run_train_with_nccl.sh --config configs/7B_sft.py"
+echo ""
+echo "3. 或者 source 环境配置文件："
+echo "   source setup_nccl_env.sh"
+echo "   python train.py --config configs/7B_sft.py"
+echo "========================================="

--- a/run_train_with_nccl.sh
+++ b/run_train_with_nccl.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# NCCL 库路径修复的训练启动脚本
+
+set -e  # 遇到错误立即退出
+
+echo "========================================="
+echo "InternEvo 训练启动脚本（带 NCCL 修复）"
+echo "========================================="
+
+# 1. 激活 conda 环境
+echo ""
+echo "[1/5] 激活 conda 环境..."
+if [ -f ~/miniconda3/etc/profile.d/conda.sh ]; then
+    source ~/miniconda3/etc/profile.d/conda.sh
+    conda activate internevo
+    echo "✓ Conda 环境已激活: internevo"
+elif [ -f ~/anaconda3/etc/profile.d/conda.sh ]; then
+    source ~/anaconda3/etc/profile.d/conda.sh
+    conda activate internevo
+    echo "✓ Conda 环境已激活: internevo"
+else
+    echo "警告: 未找到 conda 初始化脚本，尝试直接使用当前环境"
+fi
+
+# 2. 查找 NCCL 库
+echo ""
+echo "[2/5] 查找 NCCL 库..."
+
+NCCL_PATHS=()
+
+# 检查 PyTorch 自带的 NCCL
+PYTORCH_LIB=$(python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))" 2>/dev/null || echo "")
+if [ -n "$PYTORCH_LIB" ] && [ -d "$PYTORCH_LIB" ]; then
+    if ls "$PYTORCH_LIB"/libnccl.so* 1> /dev/null 2>&1; then
+        NCCL_PATHS+=("$PYTORCH_LIB")
+        echo "✓ 找到 PyTorch NCCL: $PYTORCH_LIB"
+    fi
+fi
+
+# 检查 conda 环境的 lib 目录
+CONDA_PREFIX_LIB="$CONDA_PREFIX/lib"
+if [ -n "$CONDA_PREFIX" ] && [ -d "$CONDA_PREFIX_LIB" ]; then
+    if ls "$CONDA_PREFIX_LIB"/libnccl.so* 1> /dev/null 2>&1; then
+        NCCL_PATHS+=("$CONDA_PREFIX_LIB")
+        echo "✓ 找到 Conda NCCL: $CONDA_PREFIX_LIB"
+    fi
+fi
+
+# 检查用户指定的路径（如果在 bashrc 中设置了）
+USER_NCCL_PATH="/mnt/shared-storage-user/ailab-sys/matenghui/miniconda3/envs/internevo/lib/python3.10/site-packages/nvidia/nccl/lib"
+if [ -d "$USER_NCCL_PATH" ]; then
+    if ls "$USER_NCCL_PATH"/libnccl.so* 1> /dev/null 2>&1; then
+        NCCL_PATHS+=("$USER_NCCL_PATH")
+        echo "✓ 找到用户 NCCL: $USER_NCCL_PATH"
+    fi
+fi
+
+# 3. 设置 LD_LIBRARY_PATH
+echo ""
+echo "[3/5] 设置 LD_LIBRARY_PATH..."
+
+for path in "${NCCL_PATHS[@]}"; do
+    export LD_LIBRARY_PATH="$path:$LD_LIBRARY_PATH"
+done
+
+if [ ${#NCCL_PATHS[@]} -eq 0 ]; then
+    echo "⚠ 警告: 未找到 NCCL 库，程序可能会失败"
+    echo "   尝试继续运行..."
+else
+    echo "✓ LD_LIBRARY_PATH 已设置"
+fi
+
+# 4. 验证环境
+echo ""
+echo "[4/5] 验证环境..."
+echo "Python: $(which python)"
+echo "PyTorch 版本: $(python -c 'import torch; print(torch.__version__)' 2>/dev/null || echo '未安装')"
+echo "CUDA 可用: $(python -c 'import torch; print(torch.cuda.is_available())' 2>/dev/null || echo '未知')"
+
+# 尝试验证 NCCL
+python -c "import torch; print('NCCL 版本:', torch.cuda.nccl.version())" 2>/dev/null && echo "✓ NCCL 可用" || echo "⚠ NCCL 验证失败"
+
+echo ""
+echo "当前 LD_LIBRARY_PATH:"
+echo "$LD_LIBRARY_PATH" | tr ':' '\n' | head -5
+echo ""
+
+# 5. 启动训练
+echo "[5/5] 启动训练..."
+echo "========================================="
+echo ""
+
+# 运行 Python 脚本，传递所有参数
+python train.py "$@"

--- a/setup_nccl_env.sh
+++ b/setup_nccl_env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# NCCL 环境配置脚本 - 使用方法: source setup_nccl_env.sh
+
+echo "配置 NCCL 环境..."
+
+# 方法 1: 使用 Python 自动检测 PyTorch 的库路径
+if command -v python &> /dev/null; then
+    TORCH_LIB=$(python -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'lib'))" 2>/dev/null)
+    if [ -n "$TORCH_LIB" ] && [ -d "$TORCH_LIB" ]; then
+        export LD_LIBRARY_PATH="$TORCH_LIB:$LD_LIBRARY_PATH"
+        echo "✓ 已添加 PyTorch 库路径: $TORCH_LIB"
+    fi
+fi
+
+# 方法 2: 使用 conda 环境的 lib 目录
+if [ -n "$CONDA_PREFIX" ]; then
+    export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+    echo "✓ 已添加 Conda 库路径: $CONDA_PREFIX/lib"
+fi
+
+# 方法 3: 添加用户自定义路径（如果存在）
+USER_PATHS=(
+    "/mnt/shared-storage-user/ailab-sys/matenghui/miniconda3/envs/internevo/lib"
+    "$HOME/miniconda3/envs/internevo/lib"
+)
+
+for path in "${USER_PATHS[@]}"; do
+    if [ -d "$path" ]; then
+        export LD_LIBRARY_PATH="$path:$LD_LIBRARY_PATH"
+        echo "✓ 已添加自定义路径: $path"
+    fi
+done
+
+# 验证 NCCL
+echo ""
+echo "验证 NCCL 库..."
+if ldconfig -p 2>/dev/null | grep -q nccl; then
+    echo "✓ 系统已注册 NCCL 库"
+fi
+
+# 显示最终的 LD_LIBRARY_PATH
+echo ""
+echo "当前 LD_LIBRARY_PATH 前 5 个路径:"
+echo "$LD_LIBRARY_PATH" | tr ':' '\n' | head -5
+echo ""
+echo "环境配置完成！现在可以运行训练脚本了。"


### PR DESCRIPTION
## Motivation

The user encountered a common issue where `libnccl.so.2` could not be found, despite setting `LD_LIBRARY_PATH` in `~/.bashrc`. This typically happens because `~/.bashrc` is not loaded in non-interactive environments (e.g., when running scripts, SLURM jobs, or SSH commands).

The motivation of this PR is to provide a robust and comprehensive solution for diagnosing and resolving NCCL library loading issues, ensuring programs can correctly locate `libnccl.so.2` across various execution contexts, especially in automated or batch environments.

## Modification

This PR introduces several new files to address NCCL library loading problems:

*   `NCCL_FIX_GUIDE.md`: A detailed guide explaining the problem, common causes, and multiple solutions.
*   `NCCL_QUICK_FIX.md`: A concise quick-start guide for immediate resolution.
*   `diagnose_nccl.sh`: A diagnostic script to identify the actual location of NCCL libraries and environment configuration.
*   `run_train_with_nccl.sh`: A wrapper script that automatically activates the conda environment, dynamically finds and sets `LD_LIBRARY_PATH` for NCCL, and then executes the training command.
*   `setup_nccl_env.sh`: An environment setup script to be sourced, which adds common NCCL library paths to `LD_LIBRARY_PATH`.

## BC-breaking (Optional)

No, this modification does not introduce any backward-breaking changes. It adds new utility scripts and documentation.

## Use cases (Optional)

*   Users experiencing "cannot open shared object file: No such file or directory" errors for `libnccl.so.2`.
*   Running deep learning training jobs (e.g., PyTorch) that rely on NCCL in non-interactive environments (e.g., shell scripts, SLURM/PBS job schedulers).
*   Diagnosing NCCL library path issues in complex environments.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-03fca628-d190-4204-bdab-f96322c32016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03fca628-d190-4204-bdab-f96322c32016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

